### PR TITLE
Add experimental rpicam HTTP daemon skeleton

### DIFF
--- a/apps/meson.build
+++ b/apps/meson.build
@@ -34,6 +34,12 @@ rpicam_jpeg = executable('rpicam-jpeg', files('rpicam_jpeg.cpp'),
                          link_with : rpicam_app,
                          install : true)
 
+rpicam_daemon = executable('rpicam-daemon',
+                           files('rpicam_daemon.cpp', '../daemon/camera_daemon.cpp'),
+                           include_directories : include_directories('..'),
+                           dependencies: threads_dep,
+                           install : true)
+
 # Install symlinks to the old app names for legacy purposes.
 install_symlink('libcamera-still',
                 install_dir: get_option('bindir'),

--- a/apps/rpicam_daemon.cpp
+++ b/apps/rpicam_daemon.cpp
@@ -1,0 +1,81 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * rpicam_daemon.cpp - HTTP daemon backing future DSLR-style UI workflows.
+ */
+
+#include <atomic>
+#include <chrono>
+#include <csignal>
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <thread>
+
+#include "daemon/camera_daemon.hpp"
+
+namespace
+{
+
+std::atomic<bool> keep_running{true};
+
+void signalHandler(int)
+{
+        keep_running = false;
+}
+
+uint16_t parsePort(int argc, char *argv[])
+{
+        uint16_t port = 8400;
+        for (int i = 1; i < argc; ++i)
+        {
+                std::string arg = argv[i];
+                if ((arg == "--port" || arg == "-p") && i + 1 < argc)
+                {
+                        int value = std::atoi(argv[++i]);
+                        if (value <= 0 || value > 65535)
+                                throw std::runtime_error("Port must be between 1 and 65535");
+                        port = static_cast<uint16_t>(value);
+                }
+                else if (arg == "--help" || arg == "-h")
+                {
+                        std::cout << "Usage: rpicam-daemon [--port <port>]" << std::endl;
+                        std::exit(0);
+                }
+                else
+                        throw std::runtime_error("Unknown argument: " + arg);
+        }
+        return port;
+}
+
+} // namespace
+
+int main(int argc, char *argv[])
+{
+        try
+        {
+                uint16_t port = parsePort(argc, argv);
+
+                rpicam::CameraDaemon daemon;
+                daemon.start(port);
+
+                std::signal(SIGINT, signalHandler);
+                std::signal(SIGTERM, signalHandler);
+
+                std::cout << "rpicam-daemon listening on port " << port << std::endl;
+                std::cout << "Press Ctrl+C to stop." << std::endl;
+
+                while (keep_running)
+                        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+                daemon.stop();
+        }
+        catch (std::exception const &ex)
+        {
+                std::cerr << "ERROR: " << ex.what() << std::endl;
+                return EXIT_FAILURE;
+        }
+
+        return EXIT_SUCCESS;
+}
+

--- a/daemon/camera_daemon.cpp
+++ b/daemon/camera_daemon.cpp
@@ -1,0 +1,271 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * camera_daemon.cpp - High level controller for the rpicam daemon.
+ */
+
+#include "daemon/camera_daemon.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <sstream>
+
+namespace rpicam
+{
+
+CameraDaemon::CameraDaemon() = default;
+
+void CameraDaemon::start(uint16_t port)
+{
+        registerRoutes();
+        server_.start(port);
+}
+
+void CameraDaemon::stop()
+{
+        server_.stop();
+}
+
+SessionState CameraDaemon::getState() const
+{
+        std::lock_guard<std::mutex> lock(mutex_);
+        return session_;
+}
+
+CameraSettings CameraDaemon::getSettings() const
+{
+        std::lock_guard<std::mutex> lock(mutex_);
+        return settings_;
+}
+
+bool CameraDaemon::updateSettings(JsonObject const &values, std::string &error_message)
+{
+        std::lock_guard<std::mutex> lock(mutex_);
+        CameraSettings updated = settings_;
+
+        if (auto it = values.find("fps"); it != values.end())
+        {
+                auto number = it->second.asNumber();
+                if (!number || *number <= 0)
+                {
+                        error_message = "Invalid fps value";
+                        return false;
+                }
+                updated.fps = *number;
+        }
+
+        if (auto it = values.find("shutter_us"); it != values.end())
+        {
+                auto number = it->second.asNumber();
+                if (!number || *number < 0)
+                {
+                        error_message = "Invalid shutter_us value";
+                        return false;
+                }
+                updated.shutter_us = *number;
+        }
+
+        if (auto it = values.find("analogue_gain"); it != values.end())
+        {
+                auto number = it->second.asNumber();
+                if (!number || *number <= 0)
+                {
+                        error_message = "Invalid analogue_gain value";
+                        return false;
+                }
+                updated.analogue_gain = *number;
+        }
+
+        if (auto it = values.find("auto_exposure"); it != values.end())
+        {
+                auto boolean = it->second.asBool();
+                if (!boolean)
+                {
+                        error_message = "Invalid auto_exposure value";
+                        return false;
+                }
+                updated.auto_exposure = *boolean;
+        }
+
+        settings_ = updated;
+        session_.last_error.clear();
+        return true;
+}
+
+bool CameraDaemon::startSession(SessionMode mode, std::string &error_message)
+{
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (session_.active)
+        {
+                error_message = "A session is already active";
+                return false;
+        }
+
+        session_.mode = mode;
+        session_.active = true;
+        session_.last_error.clear();
+        // Future work: kick off the appropriate libcamera pipeline.
+        return true;
+}
+
+bool CameraDaemon::stopSession(std::string &error_message)
+{
+        std::lock_guard<std::mutex> lock(mutex_);
+        if (!session_.active)
+        {
+                error_message = "No active session";
+                return false;
+        }
+
+        session_.active = false;
+        session_.mode = SessionMode::None;
+        session_.last_error.clear();
+        return true;
+}
+
+std::string CameraDaemon::buildStatusJson() const
+{
+        std::lock_guard<std::mutex> lock(mutex_);
+        std::ostringstream json;
+        std::string settings_json = buildSettingsJson(settings_);
+        json << "{\"state\":{"
+             << "\"active\":" << (session_.active ? "true" : "false")
+             << ",\"mode\":" << jsonString(modeToString(session_.mode))
+             << ",\"last_error\":" << jsonString(session_.last_error)
+             << "},\"settings\":" << settings_json
+             << "}";
+        return json.str();
+}
+
+std::string CameraDaemon::buildSettingsJson(CameraSettings const &settings)
+{
+        std::ostringstream json;
+        json << "{"
+             << "\"fps\":" << settings.fps
+             << ",\"shutter_us\":" << settings.shutter_us
+             << ",\"analogue_gain\":" << settings.analogue_gain
+             << ",\"auto_exposure\":" << (settings.auto_exposure ? "true" : "false")
+             << "}";
+        return json.str();
+}
+
+std::string CameraDaemon::modeToString(SessionMode mode)
+{
+        switch (mode)
+        {
+        case SessionMode::None: return "none";
+        case SessionMode::Preview: return "preview";
+        case SessionMode::Still: return "still";
+        case SessionMode::Video: return "video";
+        case SessionMode::CinemaDng: return "cinemadng";
+        }
+        return "none";
+}
+
+std::optional<SessionMode> CameraDaemon::modeFromString(std::string const &value)
+{
+        std::string lowered = value;
+        std::transform(lowered.begin(), lowered.end(), lowered.begin(), [](unsigned char c) { return std::tolower(c); });
+        if (lowered == "none")
+                return SessionMode::None;
+        if (lowered == "preview")
+                return SessionMode::Preview;
+        if (lowered == "still")
+                return SessionMode::Still;
+        if (lowered == "video")
+                return SessionMode::Video;
+        if (lowered == "cinemadng" || lowered == "cinedng")
+                return SessionMode::CinemaDng;
+        return std::nullopt;
+}
+
+void CameraDaemon::registerRoutes()
+{
+        server_.addHandler("GET", "/status", [this](HttpRequest const &) {
+                HttpResponse response;
+                response.body = buildStatusJson();
+                return response;
+        });
+
+        server_.addHandler("GET", "/settings", [this](HttpRequest const &) {
+                HttpResponse response;
+                CameraSettings settings = getSettings();
+                response.body = buildSettingsJson(settings);
+                return response;
+        });
+
+        server_.addHandler("POST", "/settings", [this](HttpRequest const &request) {
+                HttpResponse response;
+                std::string error;
+                JsonObject values = parseJsonObject(request.body);
+                if (!updateSettings(values, error))
+                {
+                        response.status_code = 400;
+                        response.body = "{\"error\":" + jsonString(error) + "}";
+                        return response;
+                }
+                response.body = buildSettingsJson(getSettings());
+                return response;
+        });
+
+        server_.addHandler("POST", "/session", [this](HttpRequest const &request) {
+                HttpResponse response;
+                JsonObject values = parseJsonObject(request.body);
+                auto it = values.find("mode");
+                if (it == values.end())
+                {
+                        response.status_code = 400;
+                        response.body = "{\"error\":\"Missing mode\"}";
+                        return response;
+                }
+
+                auto mode_str = it->second.asString();
+                if (!mode_str)
+                {
+                        response.status_code = 400;
+                        response.body = "{\"error\":\"Mode must be a string\"}";
+                        return response;
+                }
+
+                auto mode = modeFromString(*mode_str);
+                if (!mode)
+                {
+                        response.status_code = 400;
+                        response.body = "{\"error\":\"Unsupported mode\"}";
+                        return response;
+                }
+
+                std::string error;
+                if (!startSession(*mode, error))
+                {
+                        response.status_code = 409;
+                        response.body = "{\"error\":" + jsonString(error) + "}";
+                        return response;
+                }
+
+                response.body = buildStatusJson();
+                return response;
+        });
+
+        server_.addHandler("DELETE", "/session", [this](HttpRequest const &) {
+                HttpResponse response;
+                std::string error;
+                if (!stopSession(error))
+                {
+                        response.status_code = 409;
+                        response.body = "{\"error\":" + jsonString(error) + "}";
+                        return response;
+                }
+                response.body = buildStatusJson();
+                return response;
+        });
+
+        server_.addHandler("GET", "/preview", [](HttpRequest const &) {
+                HttpResponse response;
+                response.status_code = 503;
+                response.body = "{\"error\":\"Preview streaming is not yet implemented\"}";
+                return response;
+        });
+}
+
+} // namespace rpicam
+

--- a/daemon/camera_daemon.hpp
+++ b/daemon/camera_daemon.hpp
@@ -1,0 +1,72 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * camera_daemon.hpp - High level controller for the rpicam daemon.
+ */
+
+#pragma once
+
+#include <mutex>
+#include <optional>
+#include <string>
+
+#include "daemon/json_utils.hpp"
+#include "daemon/simple_http.hpp"
+
+namespace rpicam
+{
+
+struct CameraSettings
+{
+        double fps = 24.0;
+        double shutter_us = 0.0;
+        double analogue_gain = 1.0;
+        bool auto_exposure = true;
+};
+
+enum class SessionMode
+{
+        None,
+        Preview,
+        Still,
+        Video,
+        CinemaDng
+};
+
+struct SessionState
+{
+        SessionMode mode = SessionMode::None;
+        bool active = false;
+        std::string last_error;
+};
+
+class CameraDaemon
+{
+public:
+        CameraDaemon();
+
+        void start(uint16_t port);
+        void stop();
+
+        SessionState getState() const;
+        CameraSettings getSettings() const;
+
+        bool updateSettings(JsonObject const &values, std::string &error_message);
+        bool startSession(SessionMode mode, std::string &error_message);
+        bool stopSession(std::string &error_message);
+
+private:
+        std::string buildStatusJson() const;
+        static std::string buildSettingsJson(CameraSettings const &settings);
+        static std::string modeToString(SessionMode mode);
+        static std::optional<SessionMode> modeFromString(std::string const &value);
+
+        void registerRoutes();
+
+        mutable std::mutex mutex_;
+        SimpleHttpServer server_;
+        CameraSettings settings_;
+        SessionState session_;
+};
+
+} // namespace rpicam
+

--- a/daemon/json_utils.hpp
+++ b/daemon/json_utils.hpp
@@ -1,0 +1,190 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * json_utils.hpp - Extremely small JSON helpers for the rpicam daemon.
+ */
+
+#pragma once
+
+#include <cctype>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+
+namespace rpicam
+{
+
+struct JsonValue
+{
+        std::string text;
+        bool is_string = false;
+
+        std::optional<double> asNumber() const
+        {
+                if (is_string)
+                        return std::nullopt;
+                try
+                {
+                        size_t processed = 0;
+                        double value = std::stod(text, &processed);
+                        if (processed != text.size())
+                                return std::nullopt;
+                        return value;
+                }
+                catch (...) { return std::nullopt; }
+        }
+
+        std::optional<bool> asBool() const
+        {
+                if (is_string)
+                        return std::nullopt;
+                if (text == "true")
+                        return true;
+                if (text == "false")
+                        return false;
+                return std::nullopt;
+        }
+
+        std::optional<std::string> asString() const
+        {
+                if (!is_string)
+                        return std::nullopt;
+                return text;
+        }
+};
+
+using JsonObject = std::unordered_map<std::string, JsonValue>;
+
+inline void skipWhitespace(std::string const &body, size_t &index)
+{
+        while (index < body.size() && std::isspace(static_cast<unsigned char>(body[index])))
+                ++index;
+}
+
+inline bool expectChar(std::string const &body, size_t &index, char expected)
+{
+        skipWhitespace(body, index);
+        if (index >= body.size() || body[index] != expected)
+                return false;
+        ++index;
+        return true;
+}
+
+inline std::optional<std::string> parseString(std::string const &body, size_t &index)
+{
+        skipWhitespace(body, index);
+        if (index >= body.size() || body[index] != '"')
+                return std::nullopt;
+        ++index;
+        std::string value;
+        while (index < body.size())
+        {
+                char ch = body[index++];
+                if (ch == '"')
+                        return value;
+                if (ch == '\\' && index < body.size())
+                {
+                        char escape = body[index++];
+                        switch (escape)
+                        {
+                        case '"': value.push_back('"'); break;
+                        case '\\': value.push_back('\\'); break;
+                        case 'n': value.push_back('\n'); break;
+                        case 'r': value.push_back('\r'); break;
+                        case 't': value.push_back('\t'); break;
+                        default: value.push_back(escape); break;
+                        }
+                }
+                else
+                        value.push_back(ch);
+        }
+        return std::nullopt;
+}
+
+inline JsonObject parseJsonObject(std::string const &body)
+{
+        JsonObject result;
+        size_t index = 0;
+        if (!expectChar(body, index, '{'))
+                return result;
+
+        while (index < body.size())
+        {
+                skipWhitespace(body, index);
+                if (index < body.size() && body[index] == '}')
+                {
+                        ++index;
+                        break;
+                }
+
+                auto key = parseString(body, index);
+                if (!key)
+                        break;
+                if (!expectChar(body, index, ':'))
+                        break;
+
+                skipWhitespace(body, index);
+                JsonValue value;
+                if (index < body.size() && body[index] == '"')
+                {
+                        auto parsed = parseString(body, index);
+                        if (!parsed)
+                                break;
+                        value.text = *parsed;
+                        value.is_string = true;
+                }
+                else
+                {
+                        size_t start = index;
+                        while (index < body.size() && body[index] != ',' && body[index] != '}')
+                                ++index;
+                        size_t end = index;
+                        while (end > start && std::isspace(static_cast<unsigned char>(body[end - 1])))
+                                --end;
+                        value.text = body.substr(start, end - start);
+                }
+
+                result[*key] = value;
+
+                skipWhitespace(body, index);
+                if (index < body.size() && body[index] == ',')
+                {
+                        ++index;
+                        continue;
+                }
+                if (index < body.size() && body[index] == '}')
+                {
+                        ++index;
+                        break;
+                }
+        }
+
+        return result;
+}
+
+inline std::string jsonEscape(std::string const &input)
+{
+        std::string output;
+        output.reserve(input.size());
+        for (char c : input)
+        {
+                switch (c)
+                {
+                case '"': output += "\\\""; break;
+                case '\\': output += "\\\\"; break;
+                case '\n': output += "\\n"; break;
+                case '\r': output += "\\r"; break;
+                case '\t': output += "\\t"; break;
+                default: output.push_back(c); break;
+                }
+        }
+        return output;
+}
+
+inline std::string jsonString(std::string const &value)
+{
+        return "\"" + jsonEscape(value) + "\"";
+}
+
+} // namespace rpicam
+

--- a/daemon/simple_http.hpp
+++ b/daemon/simple_http.hpp
@@ -1,0 +1,289 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * simple_http.hpp - Minimal HTTP server utilities for the rpicam daemon.
+ */
+
+#pragma once
+
+#include <atomic>
+#include <cerrno>
+#include <csignal>
+#include <cstring>
+#include <functional>
+#include <map>
+#include <mutex>
+#include <netinet/in.h>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <sys/socket.h>
+#include <thread>
+#include <unistd.h>
+#include <utility>
+#include <vector>
+#include <sstream>
+
+namespace rpicam
+{
+
+struct HttpRequest
+{
+        std::string method;
+        std::string target;
+        std::map<std::string, std::string> headers;
+        std::string body;
+};
+
+struct HttpResponse
+{
+        int status_code = 200;
+        std::string content_type = "application/json";
+        std::string body;
+        std::vector<std::pair<std::string, std::string>> headers;
+};
+
+class SimpleHttpServer
+{
+public:
+        using Handler = std::function<HttpResponse(const HttpRequest &)>;
+
+        SimpleHttpServer();
+        ~SimpleHttpServer();
+
+        void addHandler(const std::string &method, const std::string &path, Handler handler);
+        void start(uint16_t port);
+        void stop();
+
+        bool running() const { return running_; }
+
+private:
+        void listenLoop(uint16_t port);
+        void handleClient(int client_fd);
+        bool parseRequest(int client_fd, HttpRequest &request);
+        static std::string trim(const std::string &value);
+
+        using HandlerKey = std::pair<std::string, std::string>;
+
+        struct KeyCompare
+        {
+                bool operator()(HandlerKey const &a, HandlerKey const &b) const
+                {
+                        if (a.first < b.first)
+                                return true;
+                        if (a.first > b.first)
+                                return false;
+                        return a.second < b.second;
+                }
+        };
+
+        std::map<HandlerKey, Handler, KeyCompare> handlers_;
+        std::atomic<bool> running_;
+        std::thread listen_thread_;
+        int server_fd_;
+        std::mutex handler_mutex_;
+};
+
+inline SimpleHttpServer::SimpleHttpServer() : running_(false), server_fd_(-1) {}
+
+inline SimpleHttpServer::~SimpleHttpServer()
+{
+        stop();
+}
+
+inline void SimpleHttpServer::addHandler(const std::string &method, const std::string &path, Handler handler)
+{
+        std::lock_guard<std::mutex> lock(handler_mutex_);
+        handlers_[{method, path}] = std::move(handler);
+}
+
+inline void SimpleHttpServer::start(uint16_t port)
+{
+        if (running_)
+                throw std::runtime_error("HTTP server already running");
+
+        running_ = true;
+        listen_thread_ = std::thread(&SimpleHttpServer::listenLoop, this, port);
+}
+
+inline void SimpleHttpServer::stop()
+{
+        if (!running_)
+                return;
+
+        running_ = false;
+        if (server_fd_ >= 0)
+        {
+                ::shutdown(server_fd_, SHUT_RDWR);
+                ::close(server_fd_);
+                server_fd_ = -1;
+        }
+
+        if (listen_thread_.joinable())
+                listen_thread_.join();
+}
+
+inline void SimpleHttpServer::listenLoop(uint16_t port)
+{
+        server_fd_ = ::socket(AF_INET, SOCK_STREAM, 0);
+        if (server_fd_ < 0)
+                throw std::runtime_error("Failed to create socket");
+
+        int opt = 1;
+        ::setsockopt(server_fd_, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+
+        sockaddr_in address{};
+        address.sin_family = AF_INET;
+        address.sin_addr.s_addr = htonl(INADDR_ANY);
+        address.sin_port = htons(port);
+
+        if (::bind(server_fd_, reinterpret_cast<sockaddr *>(&address), sizeof(address)) < 0)
+        {
+                int err = errno;
+                ::close(server_fd_);
+                server_fd_ = -1;
+                running_ = false;
+                throw std::runtime_error("Failed to bind HTTP server socket: " + std::string(std::strerror(err)));
+        }
+
+        if (::listen(server_fd_, 5) < 0)
+        {
+                int err = errno;
+                ::close(server_fd_);
+                server_fd_ = -1;
+                running_ = false;
+                throw std::runtime_error("Failed to listen on HTTP server socket: " + std::string(std::strerror(err)));
+        }
+
+        while (running_)
+        {
+                sockaddr_in client{};
+                socklen_t len = sizeof(client);
+                int client_fd = ::accept(server_fd_, reinterpret_cast<sockaddr *>(&client), &len);
+                if (client_fd < 0)
+                {
+                        if (running_)
+                                continue;
+                        break;
+                }
+
+                std::thread(&SimpleHttpServer::handleClient, this, client_fd).detach();
+        }
+
+        if (server_fd_ >= 0)
+        {
+                ::close(server_fd_);
+                server_fd_ = -1;
+        }
+}
+
+inline void SimpleHttpServer::handleClient(int client_fd)
+{
+        HttpRequest request;
+        if (!parseRequest(client_fd, request))
+        {
+                ::close(client_fd);
+                return;
+        }
+
+        Handler handler;
+        {
+                std::lock_guard<std::mutex> lock(handler_mutex_);
+                auto it = handlers_.find({request.method, request.target});
+                if (it != handlers_.end())
+                        handler = it->second;
+        }
+
+        HttpResponse response;
+        if (handler)
+        {
+                response = handler(request);
+        }
+        else
+        {
+                response.status_code = 404;
+                response.content_type = "application/json";
+                response.body = "{\"error\":\"Not found\"}";
+        }
+
+        std::string status_line = "HTTP/1.1 " + std::to_string(response.status_code) + "\r\n";
+        std::string headers = "Content-Type: " + response.content_type + "\r\n";
+        headers += "Content-Length: " + std::to_string(response.body.size()) + "\r\n";
+        for (auto const &h : response.headers)
+                headers += h.first + ": " + h.second + "\r\n";
+        std::string payload = status_line + headers + "Connection: close\r\n\r\n" + response.body;
+        ::send(client_fd, payload.data(), payload.size(), 0);
+        ::close(client_fd);
+}
+
+inline bool SimpleHttpServer::parseRequest(int client_fd, HttpRequest &request)
+{
+        std::string data;
+        char buffer[4096];
+        ssize_t bytes = 0;
+        bool header_complete = false;
+        size_t expected_length = 0;
+
+        while (true)
+        {
+            bytes = ::recv(client_fd, buffer, sizeof(buffer), 0);
+            if (bytes <= 0)
+                    break;
+            data.append(buffer, buffer + bytes);
+            if (!header_complete)
+            {
+                    size_t header_end = data.find("\r\n\r\n");
+                    if (header_end != std::string::npos)
+                    {
+                            header_complete = true;
+                            std::string headers_str = data.substr(0, header_end + 2);
+                            std::istringstream header_stream(headers_str);
+                            std::string request_line;
+                            if (!std::getline(header_stream, request_line))
+                                    return false;
+                            if (!request_line.empty() && request_line.back() == '\r')
+                                    request_line.pop_back();
+                            std::istringstream request_line_stream(request_line);
+                            request_line_stream >> request.method >> request.target;
+                            std::string version;
+                            request_line_stream >> version;
+                            std::string header_line;
+                            while (std::getline(header_stream, header_line))
+                            {
+                                    if (!header_line.empty() && header_line.back() == '\r')
+                                            header_line.pop_back();
+                                    if (header_line.empty())
+                                            continue;
+                                    size_t colon = header_line.find(':');
+                                    if (colon == std::string::npos)
+                                            continue;
+                                    std::string name = trim(header_line.substr(0, colon));
+                                    std::string value = trim(header_line.substr(colon + 1));
+                                    request.headers[name] = value;
+                                    if (name == "Content-Length")
+                                            expected_length = std::stoul(value);
+                            }
+                            size_t body_start = header_end + 4;
+                            request.body = data.substr(body_start);
+                            if (expected_length <= request.body.size())
+                                    return true;
+                    }
+            }
+            else if (expected_length <= request.body.size())
+                    return true;
+        }
+
+        return header_complete && expected_length <= request.body.size();
+}
+
+inline std::string SimpleHttpServer::trim(const std::string &value)
+{
+        const char *whitespace = " \t\r\n";
+        size_t start = value.find_first_not_of(whitespace);
+        size_t end = value.find_last_not_of(whitespace);
+        if (start == std::string::npos)
+                return "";
+        return value.substr(start, end - start + 1);
+}
+
+} // namespace rpicam
+

--- a/docs/rpicam-daemon.md
+++ b/docs/rpicam-daemon.md
@@ -1,0 +1,95 @@
+# rpicam-daemon
+
+`rpicam-daemon` is an experimental HTTP process that exposes an API for DSLR-style
+workflows. The daemon is intended to grow into the backend that powers the Open DSLM UI.
+
+## Building
+
+The target is built alongside the other applications:
+
+```bash
+meson setup build
+ninja -C build rpicam-daemon
+```
+
+## Running
+
+```bash
+./build/apps/rpicam-daemon --port 8400
+```
+
+The process blocks and serves until a `SIGINT`/`SIGTERM` is delivered.
+
+## HTTP endpoints
+
+All endpoints exchange JSON bodies. Responses always set `Content-Type` to
+`application/json`.
+
+### `GET /status`
+
+Returns the current session state and settings:
+
+```json
+{
+  "state": {
+    "active": false,
+    "mode": "none",
+    "last_error": ""
+  },
+  "settings": {
+    "fps": 24.0,
+    "shutter_us": 0.0,
+    "analogue_gain": 1.0,
+    "auto_exposure": true
+  }
+}
+```
+
+### `GET /settings`
+
+Returns only the current settings block.
+
+### `POST /settings`
+
+Updates the camera settings. Only the provided keys are modified. All keys are
+optional but must obey the following rules:
+
+- `fps` – floating point frames per second (> 0)
+- `shutter_us` – shutter time in microseconds (≥ 0)
+- `analogue_gain` – analogue gain (> 0)
+- `auto_exposure` – boolean
+
+Example payload:
+
+```json
+{"fps": 25.0, "auto_exposure": false}
+```
+
+### `POST /session`
+
+Starts a logical capture session.
+
+Payload:
+
+```json
+{"mode": "cinemadng"}
+```
+
+Supported modes are `preview`, `still`, `video`, `cinemadng` and `none`.
+If a session is already running the endpoint returns HTTP 409.
+
+### `DELETE /session`
+
+Stops the active session. Returns HTTP 409 if nothing is running.
+
+### `GET /preview`
+
+Currently returns HTTP 503 – the preview transport will be wired up in a
+follow-up change.
+
+## Notes
+
+This daemon currently tracks settings and state in-memory without driving the
+camera pipeline. The skeleton allows the UI to integrate while the capture,
+CinemaDNG output and HTTP streaming support are implemented incrementally.
+

--- a/meson.build
+++ b/meson.build
@@ -34,6 +34,7 @@ elif neon == 'armv8-neon'
 endif
 
 dl_dep = dependency('dl', required : true)
+threads_dep = dependency('threads', required : true)
 libcamera_dep = dependency('libcamera', required : true)
 
 summary({


### PR DESCRIPTION
## Summary
- add a new `rpicam-daemon` executable that exposes HTTP endpoints for status, settings, and session control
- provide lightweight socket-based HTTP and JSON helpers that the daemon uses for request handling
- document the experimental API and build instructions for the new daemon

## Testing
- `meson setup build` *(fails: `meson` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d6a83b64ec83278e3b55ec8cc58078